### PR TITLE
feat: Add Ollama/OpenRouter support with structured output fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@ai-sdk/anthropic": "^3.0.15",
     "@ai-sdk/google": "^3.0.10",
     "@ai-sdk/openai": "^3.0.12",
+    "@ai-sdk/openai-compatible": "^2.0.25",
     "@logseq/libs": "^0.0.17",
     "ai": "^6.0.39",
     "zod": "^4.3.5"

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,17 +8,11 @@ function getActiveConfig() {
   const settings = (logseq.settings ?? {}) as Record<string, unknown>;
   const provider = (settings.provider ?? 'google') as ProviderName;
 
-  // Construct namespaced keys based on selected provider
-  // e.g. googleApiKey, googleBaseUrl, googleModelName
-  const apiKeyKey = `${provider}ApiKey`;
-  const baseUrlKey = `${provider}BaseUrl`;
-  const modelNameKey = `${provider}ModelName`;
-
   return {
     provider,
-    apiKey: (settings[apiKeyKey] as string) || undefined,
-    baseUrl: (settings[baseUrlKey] as string) || undefined,
-    modelName: (settings[modelNameKey] as string) || undefined,
+    apiKey: (settings.aiApiKey as string) || undefined,
+    baseUrl: (settings.aiBaseUrl as string) || undefined,
+    modelName: (settings.aiModelId as string) || undefined,
     customTags: (settings.customTags ?? '#words') as string,
   };
 }
@@ -39,26 +33,22 @@ async function main() {
 
     // Validate API key (required for all except ollama)
     if (requiresApiKey(config.provider) && !config.apiKey) {
-      if (config.provider !== 'custom') {
-        logseq.UI.showMsg(
-          `Please configure API key for ${config.provider} in settings`,
-          'error'
-        );
-        return;
-      }
+      logseq.UI.showMsg(
+        `Please configure API key for ${config.provider} in settings`,
+        'error'
+      );
+      return;
     }
 
-    // Validate Base URL for providers that need it
-    if ((config.provider === 'custom' || config.provider === 'ollama') && !config.baseUrl) {
-      if (config.provider === 'custom') {
-        logseq.UI.showMsg('Base URL is required for custom provider', 'error');
-        return;
-      }
+    // Validate Base URL for openai-compatible
+    if (config.provider === 'openai-compatible' && !config.baseUrl) {
+      logseq.UI.showMsg('Base URL is required for openai-compatible provider', 'error');
+      return;
     }
 
-    // Validate Model Name for custom provider
-    if (config.provider === 'custom' && !config.modelName) {
-      logseq.UI.showMsg('Model name is required for custom provider', 'error');
+    // Validate Model Name for openai-compatible
+    if (config.provider === 'openai-compatible' && !config.modelName) {
+      logseq.UI.showMsg('Model name is required for openai-compatible provider', 'error');
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,41 @@
 import '@logseq/libs';
-import { settingsSchema } from './logseq/settings';
+import { getSettingsSchema } from './logseq/settings';
 import { formatVocabularyCard } from './logseq/blocks';
 import { generateVocabularyCard } from './vocabulary/generator';
-import type { ProviderName } from './vocabulary/providers';
+import { requiresApiKey, type ProviderName } from './vocabulary/providers';
+
+function getActiveConfig() {
+  const settings = (logseq.settings ?? {}) as Record<string, unknown>;
+  const provider = (settings.provider ?? 'google') as ProviderName;
+
+  // Construct keys dynamically
+  const apiKeyKey = `${provider}ApiKey`;
+  const baseUrlKey = `${provider}BaseUrl`;
+  const modelKey = `${provider}Model`;
+
+  return {
+    provider,
+    apiKey: (settings[apiKeyKey] as string) || undefined,
+    baseUrl: (settings[baseUrlKey] as string) || undefined,
+    modelName: (settings[modelKey] as string) || undefined,
+    customTags: (settings.customTags ?? '#words') as string,
+  };
+}
 
 async function main() {
-  logseq.useSettingsSchema(settingsSchema);
+  // Initial settings registration
+  const { provider } = getActiveConfig();
+  logseq.useSettingsSchema(getSettingsSchema(provider));
+
+  // Dynamic settings update
+  logseq.onSettingsChanged((newSettings, oldSettings) => {
+    const previousProvider = oldSettings?.provider;
+    if (newSettings.provider !== previousProvider) {
+      logseq.useSettingsSchema(
+        getSettingsSchema(newSettings.provider as ProviderName)
+      );
+    }
+  });
 
   logseq.Editor.registerSlashCommand('Generate Vocabulary Card', async () => {
     const block = await logseq.Editor.getCurrentBlock();
@@ -15,33 +45,54 @@ async function main() {
     }
 
     const word = block.content.trim();
-    const settings = logseq.settings;
-    const provider = (settings?.provider ?? 'google') as ProviderName;
-    const apiKey = settings?.apiKey as string;
-    const customTags = (settings?.customTags ?? '#words') as string;
-    const modelName = settings?.customModel as string;
+    const config = getActiveConfig();
 
-    if (!apiKey) {
-      logseq.UI.showMsg('Please configure your API key in settings', 'error');
+    // Validate API key
+    if (requiresApiKey(config.provider) && !config.apiKey) {
+      // Custom provider might have optional API key depending on the backend,
+      // but if requiresApiKey says true, we generally enforce it.
+      // However, for 'custom', the schema title says "Optional".
+      // Let's relax the check for custom if it's truly optional.
+      if (config.provider !== 'custom') {
+        logseq.UI.showMsg(
+          `Please configure ${config.provider} API key in settings`,
+          'error'
+        );
+        return;
+      }
+    }
+
+    // Validate Base URL
+    if (config.provider === 'custom' && !config.baseUrl) {
+      logseq.UI.showMsg('Base URL is required for custom provider', 'error');
+      return;
+    }
+
+    // Validate Model Name for custom provider
+    if (config.provider === 'custom' && !config.modelName) {
+      logseq.UI.showMsg('Model name is required for custom provider', 'error');
       return;
     }
 
     try {
       logseq.UI.showMsg(`Generating card for "${word}"...`, 'info');
 
-      const definition = await generateVocabularyCard(
+      const definition = await generateVocabularyCard({
         word,
-        provider,
-        apiKey,
-        undefined,
-        modelName || undefined
-      );
-      const lines = formatVocabularyCard(definition, customTags);
+        provider: config.provider,
+        apiKey: config.apiKey || undefined,
+        baseUrl: config.baseUrl || undefined,
+        modelName: config.modelName || undefined,
+      });
+
+      const lines = formatVocabularyCard(definition, config.customTags);
 
       await logseq.Editor.updateBlock(block.uuid, lines[0]);
 
       for (let i = 1; i < lines.length; i++) {
-        await logseq.Editor.insertBlock(block.uuid, lines[i], { sibling: false });
+        await logseq.Editor.insertBlock(block.uuid, lines[i], {
+          sibling: false,
+        });
       }
 
       logseq.UI.showMsg('Vocabulary card generated!', 'success');

--- a/src/logseq/settings.ts
+++ b/src/logseq/settings.ts
@@ -1,102 +1,210 @@
 import type { SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin';
-import type { ProviderName } from '../vocabulary/providers';
 
-const PROVIDER_CONFIGS: Record<ProviderName, { apiKeyTitle: string; apiKeyDesc: string; modelTitle: string; modelDesc: string; baseUrlTitle?: string; baseUrlDesc?: string; baseUrlDefault?: string }> = {
-  google: {
-    apiKeyTitle: 'Google API Key',
-    apiKeyDesc: 'Enter your Gemini API Key',
-    modelTitle: 'Model (Optional)',
-    modelDesc: 'Default: gemini-2.5-flash',
+export const settingsSchema: SettingSchemaDesc[] = [
+  // --- Provider Selection ---
+  {
+    key: 'provider',
+    type: 'enum',
+    enumChoices: ['google', 'openai', 'anthropic', 'ollama', 'openrouter', 'custom'],
+    enumPicker: 'select',
+    default: 'google',
+    title: 'AI Provider',
+    description: 'Select which provider to use for generation. Configure the specific settings below.',
   },
-  openai: {
-    apiKeyTitle: 'OpenAI API Key',
-    apiKeyDesc: 'Enter your OpenAI API Key',
-    modelTitle: 'Model (Optional)',
-    modelDesc: 'Default: gpt-5-2',
-  },
-  anthropic: {
-    apiKeyTitle: 'Anthropic API Key',
-    apiKeyDesc: 'Enter your Anthropic API Key',
-    modelTitle: 'Model (Optional)',
-    modelDesc: 'Default: claude-haiku-4-5',
-  },
-  ollama: {
-    apiKeyTitle: 'API Key (Optional)',
-    apiKeyDesc: 'Not required for Ollama, but some setups may use it',
-    baseUrlTitle: 'Base URL',
-    baseUrlDesc: 'Endpoint for local Ollama server',
-    baseUrlDefault: 'http://localhost:11434/v1',
-    modelTitle: 'Model',
-    modelDesc: 'Default: glm-4.7-flash (must be pulled first)',
-  },
-  openrouter: {
-    apiKeyTitle: 'OpenRouter API Key',
-    apiKeyDesc: 'Enter your OpenRouter API Key',
-    modelTitle: 'Model (Optional)',
-    modelDesc: 'Default: google/gemini-2.5-flash',
-  },
-  custom: {
-    apiKeyTitle: 'API Key (Optional)',
-    apiKeyDesc: 'API Key if required by your provider',
-    baseUrlTitle: 'Base URL',
-    baseUrlDesc: 'Full URL to OpenAI-compatible endpoint',
-    baseUrlDefault: '',
-    modelTitle: 'Model',
-    modelDesc: 'Model ID to request',
-  },
-};
 
-export function getSettingsSchema(provider: ProviderName = 'google'): SettingSchemaDesc[] {
-  const config = PROVIDER_CONFIGS[provider];
-  const schema: SettingSchemaDesc[] = [
-    {
-      key: 'provider',
-      type: 'enum',
-      enumChoices: ['google', 'openai', 'anthropic', 'ollama', 'openrouter', 'custom'],
-      enumPicker: 'select',
-      default: 'google',
-      title: 'AI Provider',
-      description: 'Select your preferred AI provider',
-    },
-  ];
-
-  // Base URL for providers that need it
-  if (config.baseUrlTitle) {
-    schema.push({
-      key: 'baseUrl',
-      type: 'string',
-      default: config.baseUrlDefault || '',
-      title: config.baseUrlTitle,
-      description: config.baseUrlDesc || '',
-    });
-  }
-
-  // API Key (shown for all providers, but marked optional for ollama/custom)
-  schema.push({
-    key: 'apiKey',
+  // --- Google Settings ---
+  {
+    key: 'googleHeading',
+    type: 'heading',
+    default: null,
+    title: 'Google Gemini',
+    description: '',
+  },
+  {
+    key: 'googleApiKey',
     type: 'string',
     default: '',
-    title: config.apiKeyTitle,
-    description: config.apiKeyDesc,
-  });
-
-  // Model Name
-  schema.push({
-    key: 'modelName',
+    title: 'API Key',
+    description: 'Enter your Gemini API Key',
+  },
+  {
+    key: 'googleBaseUrl',
     type: 'string',
     default: '',
-    title: config.modelTitle,
-    description: config.modelDesc,
-  });
+    title: 'Base URL (Optional)',
+    description: 'Override default Google API endpoint',
+  },
+  {
+    key: 'googleModelName',
+    type: 'string',
+    default: 'gemini-2.5-flash',
+    title: 'Model Name',
+    description: 'Default: gemini-2.5-flash',
+  },
 
-  // Custom Tags (always present)
-  schema.push({
+  // --- OpenAI Settings ---
+  {
+    key: 'openaiHeading',
+    type: 'heading',
+    default: null,
+    title: 'OpenAI',
+    description: '',
+  },
+  {
+    key: 'openaiApiKey',
+    type: 'string',
+    default: '',
+    title: 'API Key',
+    description: 'Enter your OpenAI API Key',
+  },
+  {
+    key: 'openaiBaseUrl',
+    type: 'string',
+    default: '',
+    title: 'Base URL (Optional)',
+    description: 'Override default OpenAI API endpoint',
+  },
+  {
+    key: 'openaiModelName',
+    type: 'string',
+    default: 'gpt-5-2',
+    title: 'Model Name',
+    description: 'Default: gpt-5-2',
+  },
+
+  // --- Anthropic Settings ---
+  {
+    key: 'anthropicHeading',
+    type: 'heading',
+    default: null,
+    title: 'Anthropic',
+    description: '',
+  },
+  {
+    key: 'anthropicApiKey',
+    type: 'string',
+    default: '',
+    title: 'API Key',
+    description: 'Enter your Anthropic API Key',
+  },
+  {
+    key: 'anthropicBaseUrl',
+    type: 'string',
+    default: '',
+    title: 'Base URL (Optional)',
+    description: 'Override default Anthropic API endpoint',
+  },
+  {
+    key: 'anthropicModelName',
+    type: 'string',
+    default: 'claude-haiku-4-5',
+    title: 'Model Name',
+    description: 'Default: claude-haiku-4-5',
+  },
+
+  // --- Ollama Settings ---
+  {
+    key: 'ollamaHeading',
+    type: 'heading',
+    default: null,
+    title: 'Ollama (Local)',
+    description: '',
+  },
+  {
+    key: 'ollamaBaseUrl',
+    type: 'string',
+    default: 'http://localhost:11434/v1',
+    title: 'Base URL',
+    description: 'Endpoint for local Ollama server',
+  },
+  {
+    key: 'ollamaModelName',
+    type: 'string',
+    default: 'glm-4.7-flash',
+    title: 'Model Name',
+    description: 'Default: glm-4.7-flash (must be pulled first)',
+  },
+  {
+    key: 'ollamaApiKey',
+    type: 'string',
+    default: '',
+    title: 'API Key (Optional)',
+    description: 'Not usually required for local Ollama',
+  },
+
+  // --- OpenRouter Settings ---
+  {
+    key: 'openrouterHeading',
+    type: 'heading',
+    default: null,
+    title: 'OpenRouter',
+    description: '',
+  },
+  {
+    key: 'openrouterApiKey',
+    type: 'string',
+    default: '',
+    title: 'API Key',
+    description: 'Enter your OpenRouter API Key',
+  },
+  {
+    key: 'openrouterBaseUrl',
+    type: 'string',
+    default: '',
+    title: 'Base URL (Optional)',
+    description: 'Override default OpenRouter API endpoint',
+  },
+  {
+    key: 'openrouterModelName',
+    type: 'string',
+    default: 'google/gemini-2.5-flash',
+    title: 'Model Name',
+    description: 'Default: google/gemini-2.5-flash',
+  },
+
+  // --- Custom Settings ---
+  {
+    key: 'customHeading',
+    type: 'heading',
+    default: null,
+    title: 'Custom Provider',
+    description: '',
+  },
+  {
+    key: 'customBaseUrl',
+    type: 'string',
+    default: '',
+    title: 'Base URL',
+    description: 'Full URL to OpenAI-compatible endpoint',
+  },
+  {
+    key: 'customModelName',
+    type: 'string',
+    default: '',
+    title: 'Model Name',
+    description: 'Model ID to request',
+  },
+  {
+    key: 'customApiKey',
+    type: 'string',
+    default: '',
+    title: 'API Key (Optional)',
+    description: 'API Key if required by your provider',
+  },
+
+  // --- Shared Settings ---
+  {
+    key: 'sharedHeading',
+    type: 'heading',
+    default: null,
+    title: 'General',
+    description: '',
+  },
+  {
     key: 'customTags',
     type: 'string',
     default: '#words',
     title: 'Custom Tags',
     description: 'Tags to add to vocabulary cards',
-  });
-
-  return schema;
-}
+  },
+];

--- a/src/logseq/settings.ts
+++ b/src/logseq/settings.ts
@@ -1,34 +1,66 @@
 import type { SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin';
+import type { ProviderName } from '../vocabulary/providers';
 
-export const settingsSchema: SettingSchemaDesc[] = [
-  {
-    key: 'provider',
-    type: 'enum',
-    enumChoices: ['google', 'openai', 'anthropic'],
-    enumPicker: 'select',
-    default: 'google',
-    title: 'AI Provider',
-    description: 'Select your preferred AI provider',
-  },
-  {
-    key: 'apiKey',
-    type: 'string',
-    default: '',
-    title: 'API Key',
-    description: 'API key for the selected provider',
-  },
-  {
-    key: 'customModel',
-    type: 'string',
-    default: '',
-    title: 'Custom Model (Optional)',
-    description: 'Override default model. Defaults: gemini-2.5-flash (Google), gpt-5-2 (OpenAI), claude-haiku-4-5 (Anthropic)',
-  },
-  {
+export function getSettingsSchema(provider: ProviderName = 'google'): SettingSchemaDesc[] {
+  const schema: SettingSchemaDesc[] = [
+    {
+      key: 'provider',
+      type: 'enum',
+      enumChoices: ['google', 'openai', 'anthropic', 'ollama', 'openrouter', 'custom'],
+      enumPicker: 'select',
+      default: 'google',
+      title: 'AI Provider',
+      description: 'Select your preferred AI provider',
+    },
+  ];
+
+  switch (provider) {
+    case 'google':
+      schema.push(
+        { key: 'googleApiKey', type: 'string', default: '', title: 'Google API Key', description: 'Enter your Gemini API Key' },
+        { key: 'googleModel', type: 'string', default: '', title: 'Google Model (Optional)', description: 'Default: gemini-2.5-flash' }
+      );
+      break;
+    case 'openai':
+      schema.push(
+        { key: 'openaiApiKey', type: 'string', default: '', title: 'OpenAI API Key', description: 'Enter your OpenAI API Key' },
+        { key: 'openaiModel', type: 'string', default: '', title: 'OpenAI Model (Optional)', description: 'Default: gpt-5-2' }
+      );
+      break;
+    case 'anthropic':
+      schema.push(
+        { key: 'anthropicApiKey', type: 'string', default: '', title: 'Anthropic API Key', description: 'Enter your Anthropic API Key' },
+        { key: 'anthropicModel', type: 'string', default: '', title: 'Anthropic Model (Optional)', description: 'Default: claude-haiku-4-5' }
+      );
+      break;
+    case 'ollama':
+      schema.push(
+        { key: 'ollamaBaseUrl', type: 'string', default: 'http://localhost:11434/v1', title: 'Ollama Base URL', description: 'Endpoint for local Ollama server' },
+        { key: 'ollamaModel', type: 'string', default: 'glm-4.7-flash', title: 'Ollama Model', description: 'Model to use (must be pulled first)' }
+      );
+      break;
+    case 'openrouter':
+      schema.push(
+        { key: 'openrouterApiKey', type: 'string', default: '', title: 'OpenRouter API Key', description: 'Enter your OpenRouter API Key' },
+        { key: 'openrouterModel', type: 'string', default: '', title: 'OpenRouter Model (Optional)', description: 'Default: google/gemini-2.5-flash' }
+      );
+      break;
+    case 'custom':
+      schema.push(
+        { key: 'customBaseUrl', type: 'string', default: '', title: 'Custom Provider URL', description: 'Full URL to OpenAI-compatible endpoint (e.g. http://localhost:1234/v1)' },
+        { key: 'customApiKey', type: 'string', default: '', title: 'Custom API Key (Optional)', description: 'API Key if required by provider' },
+        { key: 'customModel', type: 'string', default: '', title: 'Custom Model Name', description: 'Model ID to request' }
+      );
+      break;
+  }
+
+  schema.push({
     key: 'customTags',
     type: 'string',
     default: '#words',
     title: 'Custom Tags',
     description: 'Tags to add to vocabulary cards',
-  },
-];
+  });
+
+  return schema;
+}

--- a/src/logseq/settings.ts
+++ b/src/logseq/settings.ts
@@ -1,7 +1,53 @@
 import type { SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin';
 import type { ProviderName } from '../vocabulary/providers';
 
+const PROVIDER_CONFIGS: Record<ProviderName, { apiKeyTitle: string; apiKeyDesc: string; modelTitle: string; modelDesc: string; baseUrlTitle?: string; baseUrlDesc?: string; baseUrlDefault?: string }> = {
+  google: {
+    apiKeyTitle: 'Google API Key',
+    apiKeyDesc: 'Enter your Gemini API Key',
+    modelTitle: 'Model (Optional)',
+    modelDesc: 'Default: gemini-2.5-flash',
+  },
+  openai: {
+    apiKeyTitle: 'OpenAI API Key',
+    apiKeyDesc: 'Enter your OpenAI API Key',
+    modelTitle: 'Model (Optional)',
+    modelDesc: 'Default: gpt-5-2',
+  },
+  anthropic: {
+    apiKeyTitle: 'Anthropic API Key',
+    apiKeyDesc: 'Enter your Anthropic API Key',
+    modelTitle: 'Model (Optional)',
+    modelDesc: 'Default: claude-haiku-4-5',
+  },
+  ollama: {
+    apiKeyTitle: 'API Key (Optional)',
+    apiKeyDesc: 'Not required for Ollama, but some setups may use it',
+    baseUrlTitle: 'Base URL',
+    baseUrlDesc: 'Endpoint for local Ollama server',
+    baseUrlDefault: 'http://localhost:11434/v1',
+    modelTitle: 'Model',
+    modelDesc: 'Default: glm-4.7-flash (must be pulled first)',
+  },
+  openrouter: {
+    apiKeyTitle: 'OpenRouter API Key',
+    apiKeyDesc: 'Enter your OpenRouter API Key',
+    modelTitle: 'Model (Optional)',
+    modelDesc: 'Default: google/gemini-2.5-flash',
+  },
+  custom: {
+    apiKeyTitle: 'API Key (Optional)',
+    apiKeyDesc: 'API Key if required by your provider',
+    baseUrlTitle: 'Base URL',
+    baseUrlDesc: 'Full URL to OpenAI-compatible endpoint',
+    baseUrlDefault: '',
+    modelTitle: 'Model',
+    modelDesc: 'Model ID to request',
+  },
+};
+
 export function getSettingsSchema(provider: ProviderName = 'google'): SettingSchemaDesc[] {
+  const config = PROVIDER_CONFIGS[provider];
   const schema: SettingSchemaDesc[] = [
     {
       key: 'provider',
@@ -14,46 +60,36 @@ export function getSettingsSchema(provider: ProviderName = 'google'): SettingSch
     },
   ];
 
-  switch (provider) {
-    case 'google':
-      schema.push(
-        { key: 'googleApiKey', type: 'string', default: '', title: 'Google API Key', description: 'Enter your Gemini API Key' },
-        { key: 'googleModel', type: 'string', default: '', title: 'Google Model (Optional)', description: 'Default: gemini-2.5-flash' }
-      );
-      break;
-    case 'openai':
-      schema.push(
-        { key: 'openaiApiKey', type: 'string', default: '', title: 'OpenAI API Key', description: 'Enter your OpenAI API Key' },
-        { key: 'openaiModel', type: 'string', default: '', title: 'OpenAI Model (Optional)', description: 'Default: gpt-5-2' }
-      );
-      break;
-    case 'anthropic':
-      schema.push(
-        { key: 'anthropicApiKey', type: 'string', default: '', title: 'Anthropic API Key', description: 'Enter your Anthropic API Key' },
-        { key: 'anthropicModel', type: 'string', default: '', title: 'Anthropic Model (Optional)', description: 'Default: claude-haiku-4-5' }
-      );
-      break;
-    case 'ollama':
-      schema.push(
-        { key: 'ollamaBaseUrl', type: 'string', default: 'http://localhost:11434/v1', title: 'Ollama Base URL', description: 'Endpoint for local Ollama server' },
-        { key: 'ollamaModel', type: 'string', default: 'glm-4.7-flash', title: 'Ollama Model', description: 'Model to use (must be pulled first)' }
-      );
-      break;
-    case 'openrouter':
-      schema.push(
-        { key: 'openrouterApiKey', type: 'string', default: '', title: 'OpenRouter API Key', description: 'Enter your OpenRouter API Key' },
-        { key: 'openrouterModel', type: 'string', default: '', title: 'OpenRouter Model (Optional)', description: 'Default: google/gemini-2.5-flash' }
-      );
-      break;
-    case 'custom':
-      schema.push(
-        { key: 'customBaseUrl', type: 'string', default: '', title: 'Custom Provider URL', description: 'Full URL to OpenAI-compatible endpoint (e.g. http://localhost:1234/v1)' },
-        { key: 'customApiKey', type: 'string', default: '', title: 'Custom API Key (Optional)', description: 'API Key if required by provider' },
-        { key: 'customModel', type: 'string', default: '', title: 'Custom Model Name', description: 'Model ID to request' }
-      );
-      break;
+  // Base URL for providers that need it
+  if (config.baseUrlTitle) {
+    schema.push({
+      key: 'baseUrl',
+      type: 'string',
+      default: config.baseUrlDefault || '',
+      title: config.baseUrlTitle,
+      description: config.baseUrlDesc || '',
+    });
   }
 
+  // API Key (shown for all providers, but marked optional for ollama/custom)
+  schema.push({
+    key: 'apiKey',
+    type: 'string',
+    default: '',
+    title: config.apiKeyTitle,
+    description: config.apiKeyDesc,
+  });
+
+  // Model Name
+  schema.push({
+    key: 'modelName',
+    type: 'string',
+    default: '',
+    title: config.modelTitle,
+    description: config.modelDesc,
+  });
+
+  // Custom Tags (always present)
   schema.push({
     key: 'customTags',
     type: 'string',

--- a/src/logseq/settings.ts
+++ b/src/logseq/settings.ts
@@ -5,196 +5,46 @@ export const settingsSchema: SettingSchemaDesc[] = [
   {
     key: 'provider',
     type: 'enum',
-    enumChoices: ['google', 'openai', 'anthropic', 'ollama', 'openrouter', 'custom'],
+    enumChoices: ['google', 'openai', 'anthropic', 'ollama', 'openrouter', 'openai-compatible'],
     enumPicker: 'select',
     default: 'google',
     title: 'AI Provider',
     description: 'Select which provider to use for generation. Configure the specific settings below.',
   },
 
-  // --- Google Settings ---
+  // --- AI Configuration ---
   {
-    key: 'googleHeading',
+    key: 'aiConfigHeading',
     type: 'heading',
     default: null,
-    title: 'Google Gemini',
+    title: 'AI Configuration',
     description: '',
   },
   {
-    key: 'googleApiKey',
+    key: 'aiModelId',
     type: 'string',
     default: '',
-    title: 'API Key',
-    description: 'Enter your Gemini API Key',
+    title: 'Model ID',
+    description: 'Model identifier (e.g., gemini-2.5-flash, gpt-5-2, claude-haiku-4-5)',
   },
   {
-    key: 'googleBaseUrl',
-    type: 'string',
-    default: '',
-    title: 'Base URL (Optional)',
-    description: 'Override default Google API endpoint',
-  },
-  {
-    key: 'googleModelName',
-    type: 'string',
-    default: 'gemini-2.5-flash',
-    title: 'Model Name',
-    description: 'Default: gemini-2.5-flash',
-  },
-
-  // --- OpenAI Settings ---
-  {
-    key: 'openaiHeading',
-    type: 'heading',
-    default: null,
-    title: 'OpenAI',
-    description: '',
-  },
-  {
-    key: 'openaiApiKey',
-    type: 'string',
-    default: '',
-    title: 'API Key',
-    description: 'Enter your OpenAI API Key',
-  },
-  {
-    key: 'openaiBaseUrl',
-    type: 'string',
-    default: '',
-    title: 'Base URL (Optional)',
-    description: 'Override default OpenAI API endpoint',
-  },
-  {
-    key: 'openaiModelName',
-    type: 'string',
-    default: 'gpt-5-2',
-    title: 'Model Name',
-    description: 'Default: gpt-5-2',
-  },
-
-  // --- Anthropic Settings ---
-  {
-    key: 'anthropicHeading',
-    type: 'heading',
-    default: null,
-    title: 'Anthropic',
-    description: '',
-  },
-  {
-    key: 'anthropicApiKey',
-    type: 'string',
-    default: '',
-    title: 'API Key',
-    description: 'Enter your Anthropic API Key',
-  },
-  {
-    key: 'anthropicBaseUrl',
-    type: 'string',
-    default: '',
-    title: 'Base URL (Optional)',
-    description: 'Override default Anthropic API endpoint',
-  },
-  {
-    key: 'anthropicModelName',
-    type: 'string',
-    default: 'claude-haiku-4-5',
-    title: 'Model Name',
-    description: 'Default: claude-haiku-4-5',
-  },
-
-  // --- Ollama Settings ---
-  {
-    key: 'ollamaHeading',
-    type: 'heading',
-    default: null,
-    title: 'Ollama (Local)',
-    description: '',
-  },
-  {
-    key: 'ollamaBaseUrl',
-    type: 'string',
-    default: 'http://localhost:11434/v1',
-    title: 'Base URL',
-    description: 'Endpoint for local Ollama server',
-  },
-  {
-    key: 'ollamaModelName',
-    type: 'string',
-    default: 'glm-4.7-flash',
-    title: 'Model Name',
-    description: 'Default: glm-4.7-flash (must be pulled first)',
-  },
-  {
-    key: 'ollamaApiKey',
+    key: 'aiApiKey',
     type: 'string',
     default: '',
     title: 'API Key (Optional)',
-    description: 'Not usually required for local Ollama',
-  },
-
-  // --- OpenRouter Settings ---
-  {
-    key: 'openrouterHeading',
-    type: 'heading',
-    default: null,
-    title: 'OpenRouter',
-    description: '',
+    description: 'API key for the provider (not required for Ollama and some other providers)',
   },
   {
-    key: 'openrouterApiKey',
-    type: 'string',
-    default: '',
-    title: 'API Key',
-    description: 'Enter your OpenRouter API Key',
-  },
-  {
-    key: 'openrouterBaseUrl',
+    key: 'aiBaseUrl',
     type: 'string',
     default: '',
     title: 'Base URL (Optional)',
-    description: 'Override default OpenRouter API endpoint',
-  },
-  {
-    key: 'openrouterModelName',
-    type: 'string',
-    default: 'google/gemini-2.5-flash',
-    title: 'Model Name',
-    description: 'Default: google/gemini-2.5-flash',
+    description: 'Override the default API endpoint URL',
   },
 
-  // --- Custom Settings ---
+  // --- General Settings ---
   {
-    key: 'customHeading',
-    type: 'heading',
-    default: null,
-    title: 'Custom Provider',
-    description: '',
-  },
-  {
-    key: 'customBaseUrl',
-    type: 'string',
-    default: '',
-    title: 'Base URL',
-    description: 'Full URL to OpenAI-compatible endpoint',
-  },
-  {
-    key: 'customModelName',
-    type: 'string',
-    default: '',
-    title: 'Model Name',
-    description: 'Model ID to request',
-  },
-  {
-    key: 'customApiKey',
-    type: 'string',
-    default: '',
-    title: 'API Key (Optional)',
-    description: 'API Key if required by your provider',
-  },
-
-  // --- Shared Settings ---
-  {
-    key: 'sharedHeading',
+    key: 'generalHeading',
     type: 'heading',
     default: null,
     title: 'General',

--- a/src/vocabulary/generator.test.ts
+++ b/src/vocabulary/generator.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'bun:test';
+import type { LanguageModel } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
 import { generateVocabularyCard } from './generator';
 
@@ -117,6 +118,103 @@ describe('generateVocabularyCard', () => {
           model: invalidModel,
         })
       ).rejects.toThrow();
+    });
+
+    it('falls back to manual JSON parsing when structured output is not supported', async () => {
+      const fallbackResponse = {
+        word: 'ephemeral',
+        pronunciation: '/ɪˈfem(ə)rəl/',
+        definition: 'lasting for a very short time',
+        examples: ['Fame is ephemeral.', 'The ephemeral beauty of cherry blossoms.'],
+      };
+
+      let callCount = 0;
+      const mockModel = new MockLanguageModelV3({
+        doGenerate: async () => {
+          callCount++;
+          if (callCount === 1) {
+            throw new Error('response_format.type not supported by this model');
+          }
+          return {
+            content: [{ type: 'text', text: JSON.stringify(fallbackResponse) }],
+            finishReason: { unified: 'stop', raw: undefined },
+            usage: {
+              inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+              outputTokens: { total: 20, text: 20, reasoning: undefined },
+            },
+            warnings: [],
+          };
+        },
+      });
+
+      const result = await generateVocabularyCard({
+        word: 'ephemeral',
+        provider: 'google',
+        apiKey: 'fake-key',
+        model: mockModel as unknown as LanguageModel,
+      });
+
+      expect(callCount).toBe(2);
+      expect(result.word).toBe('ephemeral');
+      expect(result.examples).toHaveLength(2);
+    });
+
+    it('handles markdown code blocks in fallback response', async () => {
+      const fallbackResponse = {
+        word: 'luminous',
+        pronunciation: '/ˈlo͞omənəs/',
+        definition: 'full of or shedding light; bright or shining',
+        examples: ['The luminous moon illuminated the path.', 'Her luminous smile lit up the room.'],
+      };
+
+      let callCount = 0;
+      const mockModel = new MockLanguageModelV3({
+        doGenerate: async () => {
+          callCount++;
+          if (callCount === 1) {
+            throw new Error('json_object not supported');
+          }
+          return {
+            content: [{ type: 'text', text: '```json\n' + JSON.stringify(fallbackResponse) + '\n```' }],
+            finishReason: { unified: 'stop', raw: undefined },
+            usage: {
+              inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+              outputTokens: { total: 20, text: 20, reasoning: undefined },
+            },
+            warnings: [],
+          };
+        },
+      });
+
+      const result = await generateVocabularyCard({
+        word: 'luminous',
+        provider: 'google',
+        apiKey: 'fake-key',
+        model: mockModel as unknown as LanguageModel,
+      });
+
+      expect(callCount).toBe(2);
+      expect(result.word).toBe('luminous');
+      expect(result.examples).toHaveLength(2);
+    });
+
+    it('re-throws non-structured-output errors', async () => {
+      const mockError = new Error('API key invalid');
+
+      const mockModel = new MockLanguageModelV3({
+        doGenerate: async () => {
+          throw mockError;
+        },
+      });
+
+      await expect(
+        generateVocabularyCard({
+          word: 'test',
+          provider: 'google',
+          apiKey: 'bad-key',
+          model: mockModel as unknown as LanguageModel,
+        })
+      ).rejects.toThrow('API key invalid');
     });
   });
 });

--- a/src/vocabulary/generator.test.ts
+++ b/src/vocabulary/generator.test.ts
@@ -25,12 +25,12 @@ describe('generateVocabularyCard', () => {
       examples: ['Fame is ephemeral.', 'The ephemeral beauty of cherry blossoms.'],
     };
 
-    const result = await generateVocabularyCard(
-      'ephemeral',
-      'google',
-      'fake-api-key',
-      createMockModel(mockResponse)
-    );
+    const result = await generateVocabularyCard({
+      word: 'ephemeral',
+      provider: 'google',
+      apiKey: 'fake-api-key',
+      model: createMockModel(mockResponse),
+    });
 
     expect(result.word).toBe('ephemeral');
     expect(result.pronunciation).toBe('/ɪˈfem(ə)rəl/');
@@ -46,13 +46,13 @@ describe('generateVocabularyCard', () => {
       examples: ['First example.', 'Second example.'],
     };
 
-    const result = await generateVocabularyCard(
-      'test',
-      'google',
-      'fake-api-key',
-      createMockModel(mockResponse),
-      'gemini-3-flash-preview'
-    );
+    const result = await generateVocabularyCard({
+      word: 'test',
+      provider: 'google',
+      apiKey: 'fake-api-key',
+      model: createMockModel(mockResponse),
+      modelName: 'gemini-3-flash-preview',
+    });
 
     expect(result.word).toBe('test');
   });
@@ -72,7 +72,12 @@ describe('generateVocabularyCard', () => {
       });
 
       await expect(
-        generateVocabularyCard('test', 'google', 'fake-key', invalidModel)
+        generateVocabularyCard({
+          word: 'test',
+          provider: 'google',
+          apiKey: 'fake-key',
+          model: invalidModel,
+        })
       ).rejects.toThrow();
     });
 
@@ -80,13 +85,17 @@ describe('generateVocabularyCard', () => {
       const incompleteResponse = {
         word: 'test',
         pronunciation: '/test/',
-        // missing: definition, examples
       };
 
       const invalidModel = createMockModel(incompleteResponse);
 
       await expect(
-        generateVocabularyCard('test', 'google', 'fake-key', invalidModel)
+        generateVocabularyCard({
+          word: 'test',
+          provider: 'google',
+          apiKey: 'fake-key',
+          model: invalidModel,
+        })
       ).rejects.toThrow();
     });
 
@@ -95,13 +104,18 @@ describe('generateVocabularyCard', () => {
         word: 'test',
         pronunciation: '/test/',
         definition: 'a test word',
-        examples: ['Only one example'], // should be exactly 2
+        examples: ['Only one example'],
       };
 
       const invalidModel = createMockModel(wrongExamplesResponse);
 
       await expect(
-        generateVocabularyCard('test', 'google', 'fake-key', invalidModel)
+        generateVocabularyCard({
+          word: 'test',
+          provider: 'google',
+          apiKey: 'fake-key',
+          model: invalidModel,
+        })
       ).rejects.toThrow();
     });
   });

--- a/src/vocabulary/generator.ts
+++ b/src/vocabulary/generator.ts
@@ -7,14 +7,19 @@ export const SYSTEM_PROMPT = `You are a vocabulary dictionary assistant.
 Provide accurate word definitions with phonetic pronunciation, 
 clear explanations, and helpful example sentences.`;
 
-export async function generateVocabularyCard(
-  word: string,
-  provider: ProviderName,
-  apiKey: string,
-  model?: LanguageModel,
-  modelName?: string
-): Promise<WordDefinition> {
-  const resolvedModel = model ?? await createModel(provider, apiKey, modelName);
+export interface GenerateOptions {
+  word: string;
+  provider: ProviderName;
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  model?: LanguageModel;
+}
+
+export async function generateVocabularyCard(options: GenerateOptions): Promise<WordDefinition> {
+  const { word, provider, apiKey, baseUrl, modelName, model } = options;
+
+  const resolvedModel = model ?? await createModel({ provider, apiKey, baseUrl, modelName });
 
   const { output } = await generateText({
     model: resolvedModel,

--- a/src/vocabulary/generator.ts
+++ b/src/vocabulary/generator.ts
@@ -16,19 +16,63 @@ export interface GenerateOptions {
   model?: LanguageModel;
 }
 
+function isStructuredOutputError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    const errorName = error.constructor.name;
+    
+    return (
+      errorName === 'AI_NoObjectGeneratedError' ||
+      (message.includes('response_format') && message.includes('not supported')) ||
+      (message.includes('json_object') && message.includes('not supported')) ||
+      message.includes('json mode cannot be combined with')
+    );
+  }
+  return false;
+}
+
+async function generateWithManualParsing(
+  model: LanguageModel,
+  word: string
+): Promise<WordDefinition> {
+  const { text } = await generateText({
+    model,
+    system: `${SYSTEM_PROMPT}\n\nIMPORTANT: Respond ONLY with valid JSON in the following format:
+{
+  "word": "string",
+  "pronunciation": "string",
+  "definition": "string",
+  "examples": ["sentence1", "sentence2"]
+}`,
+    prompt: `Define the word: "${word}" and respond with JSON only.`,
+  });
+
+  const cleanedText = text.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+  const parsed = JSON.parse(cleanedText);
+  return WordDefinitionSchema.parse(parsed);
+}
+
 export async function generateVocabularyCard(options: GenerateOptions): Promise<WordDefinition> {
   const { word, provider, apiKey, baseUrl, modelName, model } = options;
 
   const resolvedModel = model ?? await createModel({ provider, apiKey, baseUrl, modelName });
 
-  const { output } = await generateText({
-    model: resolvedModel,
-    output: Output.object({
-      schema: WordDefinitionSchema,
-    }),
-    system: SYSTEM_PROMPT,
-    prompt: `Define the word: "${word}"`,
-  });
+  try {
+    const { output } = await generateText({
+      model: resolvedModel,
+      output: Output.object({
+        schema: WordDefinitionSchema,
+      }),
+      system: SYSTEM_PROMPT,
+      prompt: `Define the word: "${word}"`,
+    });
 
-  return output;
+    return output;
+  } catch (error) {
+    if (isStructuredOutputError(error)) {
+      console.warn('Structured output not supported by this model, falling back to manual JSON parsing');
+      return generateWithManualParsing(resolvedModel, word);
+    }
+    throw error;
+  }
 }

--- a/src/vocabulary/providers.test.ts
+++ b/src/vocabulary/providers.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'bun:test';
-import { createModel, type ProviderName } from './providers';
+import { createModel, requiresApiKey, type ProviderName } from './providers';
 
 describe('createModel', () => {
   const testApiKey = 'test-api-key-12345';
 
   it('creates Google Gemini model with default version', async () => {
-    const model = await createModel('google', testApiKey);
+    const model = await createModel({ provider: 'google', apiKey: testApiKey });
 
     expect(model).toBeDefined();
     const modelObj = model as { modelId: string; provider: string };
@@ -14,7 +14,7 @@ describe('createModel', () => {
   });
 
   it('creates Google Gemini model with custom model name', async () => {
-    const model = await createModel('google', testApiKey, 'gemini-3-flash-preview');
+    const model = await createModel({ provider: 'google', apiKey: testApiKey, modelName: 'gemini-3-flash-preview' });
 
     expect(model).toBeDefined();
     const modelObj = model as { modelId: string; provider: string };
@@ -23,7 +23,7 @@ describe('createModel', () => {
   });
 
   it('creates OpenAI model with default version', async () => {
-    const model = await createModel('openai', testApiKey);
+    const model = await createModel({ provider: 'openai', apiKey: testApiKey });
 
     expect(model).toBeDefined();
     const modelObj = model as { modelId: string; provider: string };
@@ -32,7 +32,7 @@ describe('createModel', () => {
   });
 
   it('creates OpenAI model with custom model name', async () => {
-    const model = await createModel('openai', testApiKey, 'gpt-4o-mini');
+    const model = await createModel({ provider: 'openai', apiKey: testApiKey, modelName: 'gpt-4o-mini' });
 
     expect(model).toBeDefined();
     const modelObj = model as { modelId: string; provider: string };
@@ -41,7 +41,7 @@ describe('createModel', () => {
   });
 
   it('creates Anthropic model with default version', async () => {
-    const model = await createModel('anthropic', testApiKey);
+    const model = await createModel({ provider: 'anthropic', apiKey: testApiKey });
 
     expect(model).toBeDefined();
     const modelObj = model as { modelId: string; provider: string };
@@ -50,7 +50,7 @@ describe('createModel', () => {
   });
 
   it('creates Anthropic model with custom model name', async () => {
-    const model = await createModel('anthropic', testApiKey, 'claude-opus-4-5-20251101');
+    const model = await createModel({ provider: 'anthropic', apiKey: testApiKey, modelName: 'claude-opus-4-5-20251101' });
 
     expect(model).toBeDefined();
     const modelObj = model as { modelId: string; provider: string };
@@ -58,19 +58,110 @@ describe('createModel', () => {
     expect(modelObj.provider).toBe('anthropic.messages');
   });
 
+  describe('ollama', () => {
+    it('creates model with default base URL', async () => {
+      const model = await createModel({ provider: 'ollama' });
+
+      expect(model).toBeDefined();
+      const modelObj = model as { modelId: string };
+      expect(modelObj.modelId).toBe('glm-4.7-flash');
+    });
+
+    it('creates model with custom base URL', async () => {
+      const model = await createModel({
+        provider: 'ollama',
+        baseUrl: 'http://192.168.1.100:11434/v1',
+        modelName: 'mistral',
+      });
+
+      expect(model).toBeDefined();
+      const modelObj = model as { modelId: string };
+      expect(modelObj.modelId).toBe('mistral');
+    });
+  });
+
+  describe('openrouter', () => {
+    it('creates model with API key', async () => {
+      const model = await createModel({
+        provider: 'openrouter',
+        apiKey: 'sk-or-test-key',
+      });
+
+      expect(model).toBeDefined();
+      const modelObj = model as { modelId: string };
+      expect(modelObj.modelId).toBe('google/gemini-2.5-flash');
+    });
+
+    it('creates model with custom model', async () => {
+      const model = await createModel({
+        provider: 'openrouter',
+        apiKey: 'sk-or-test-key',
+        modelName: 'anthropic/claude-3-haiku',
+      });
+
+      expect(model).toBeDefined();
+      const modelObj = model as { modelId: string };
+      expect(modelObj.modelId).toBe('anthropic/claude-3-haiku');
+    });
+  });
+
+  describe('custom', () => {
+    it('throws when baseUrl is missing', async () => {
+      await expect(
+        createModel({ provider: 'custom', modelName: 'test-model' })
+      ).rejects.toThrow('Base URL required');
+    });
+
+    it('throws when modelName is missing', async () => {
+      await expect(
+        createModel({ provider: 'custom', baseUrl: 'http://localhost:8080/v1' })
+      ).rejects.toThrow('Model name required');
+    });
+
+    it('creates model with custom config', async () => {
+      const model = await createModel({
+        provider: 'custom',
+        baseUrl: 'http://localhost:8080/v1',
+        modelName: 'my-model',
+        apiKey: 'my-key',
+      });
+
+      expect(model).toBeDefined();
+      const modelObj = model as { modelId: string };
+      expect(modelObj.modelId).toBe('my-model');
+    });
+  });
+
   it('handles all provider types exhaustively', async () => {
-    const providers: ProviderName[] = ['google', 'openai', 'anthropic'];
-    const expectedProviderStrings: Record<ProviderName, string> = {
+    type TestableProvider = Exclude<ProviderName, 'custom'>;
+    const providers: TestableProvider[] = ['google', 'openai', 'anthropic', 'ollama', 'openrouter'];
+    const expectedProviderStrings: Record<TestableProvider, string> = {
       google: 'google.generative-ai',
       openai: 'openai.responses',
       anthropic: 'anthropic.messages',
+      ollama: 'ollama.chat',
+      openrouter: 'openrouter.chat',
     };
 
     for (const provider of providers) {
-      const model = await createModel(provider, testApiKey);
+      const model = await createModel({
+        provider,
+        apiKey: provider === 'ollama' ? undefined : testApiKey,
+      });
       expect(model).toBeDefined();
       const modelObj = model as { provider: string };
       expect(modelObj.provider).toBe(expectedProviderStrings[provider]);
     }
+  });
+});
+
+describe('requiresApiKey', () => {
+  it('returns false for ollama', () => {
+    expect(requiresApiKey('ollama')).toBe(false);
+  });
+
+  it('returns true for cloud providers', () => {
+    const cloudProviders: ProviderName[] = ['google', 'openai', 'anthropic', 'openrouter', 'custom'];
+    cloudProviders.forEach((p) => expect(requiresApiKey(p)).toBe(true));
   });
 });

--- a/src/vocabulary/providers.ts
+++ b/src/vocabulary/providers.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel } from 'ai';
 
-export type ProviderName = 'google' | 'openai' | 'anthropic' | 'ollama' | 'openrouter' | 'custom';
+export type ProviderName = 'google' | 'openai' | 'anthropic' | 'ollama' | 'openrouter' | 'openai-compatible';
 
 export interface CreateModelOptions {
   provider: ProviderName;
@@ -43,27 +43,13 @@ export async function createModel(options: CreateModelOptions): Promise<Language
         baseURL: baseUrl || undefined,
       })(modelName ?? 'claude-haiku-4-5');
     }
-    case 'openai': {
-      const { createOpenAI } = await import('@ai-sdk/openai');
-      return createOpenAI({ 
-        apiKey: apiKey!,
-        baseURL: baseUrl || undefined
-      })(modelName ?? 'gpt-5-2');
-    }
-    case 'anthropic': {
-      const { createAnthropic } = await import('@ai-sdk/anthropic');
-      return createAnthropic({ 
-        apiKey: apiKey!,
-        baseURL: baseUrl || undefined
-      })(modelName ?? 'claude-haiku-4-5');
-    }
     case 'ollama': {
       const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible');
       const defaults = PROVIDER_DEFAULTS.ollama;
       const provider = createOpenAICompatible({
         name: 'ollama',
         baseURL: baseUrl ?? defaults.baseUrl,
-        apiKey: 'ollama',
+        apiKey: apiKey || 'ollama',
       });
       return provider.chatModel(modelName ?? defaults.model);
     }
@@ -77,12 +63,12 @@ export async function createModel(options: CreateModelOptions): Promise<Language
       });
       return provider.chatModel(modelName ?? defaults.model);
     }
-    case 'custom': {
+    case 'openai-compatible': {
       const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible');
-      if (!baseUrl) throw new Error('Base URL required for custom provider');
-      if (!modelName) throw new Error('Model name required for custom provider');
+      if (!baseUrl) throw new Error('Base URL required for openai-compatible provider');
+      if (!modelName) throw new Error('Model name required for openai-compatible provider');
       const provider = createOpenAICompatible({
-        name: 'custom',
+        name: 'openai-compatible',
         baseURL: baseUrl,
         apiKey: apiKey ?? 'none',
       });

--- a/src/vocabulary/providers.ts
+++ b/src/vocabulary/providers.ts
@@ -24,15 +24,38 @@ export async function createModel(options: CreateModelOptions): Promise<Language
   switch (provider) {
     case 'google': {
       const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
-      return createGoogleGenerativeAI({ apiKey: apiKey! })(modelName ?? 'gemini-2.5-flash');
+      return createGoogleGenerativeAI({
+        apiKey: apiKey!,
+        baseURL: baseUrl || undefined,
+      })(modelName ?? 'gemini-2.5-flash');
     }
     case 'openai': {
       const { createOpenAI } = await import('@ai-sdk/openai');
-      return createOpenAI({ apiKey: apiKey! })(modelName ?? 'gpt-5-2');
+      return createOpenAI({
+        apiKey: apiKey!,
+        baseURL: baseUrl || undefined,
+      })(modelName ?? 'gpt-5-2');
     }
     case 'anthropic': {
       const { createAnthropic } = await import('@ai-sdk/anthropic');
-      return createAnthropic({ apiKey: apiKey! })(modelName ?? 'claude-haiku-4-5');
+      return createAnthropic({
+        apiKey: apiKey!,
+        baseURL: baseUrl || undefined,
+      })(modelName ?? 'claude-haiku-4-5');
+    }
+    case 'openai': {
+      const { createOpenAI } = await import('@ai-sdk/openai');
+      return createOpenAI({ 
+        apiKey: apiKey!,
+        baseURL: baseUrl || undefined
+      })(modelName ?? 'gpt-5-2');
+    }
+    case 'anthropic': {
+      const { createAnthropic } = await import('@ai-sdk/anthropic');
+      return createAnthropic({ 
+        apiKey: apiKey!,
+        baseURL: baseUrl || undefined
+      })(modelName ?? 'claude-haiku-4-5');
     }
     case 'ollama': {
       const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible');

--- a/src/vocabulary/providers.ts
+++ b/src/vocabulary/providers.ts
@@ -1,24 +1,69 @@
 import type { LanguageModel } from 'ai';
 
-export type ProviderName = 'google' | 'openai' | 'anthropic';
+export type ProviderName = 'google' | 'openai' | 'anthropic' | 'ollama' | 'openrouter' | 'custom';
 
-export async function createModel(
-  provider: ProviderName,
-  apiKey: string,
-  modelName?: string
-): Promise<LanguageModel> {
+export interface CreateModelOptions {
+  provider: ProviderName;
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+}
+
+const PROVIDER_DEFAULTS: Record<string, { baseUrl: string; model: string }> = {
+  ollama: { baseUrl: 'http://localhost:11434/v1', model: 'glm-4.7-flash' },
+  openrouter: { baseUrl: 'https://openrouter.ai/api/v1', model: 'google/gemini-2.5-flash' },
+};
+
+export function requiresApiKey(provider: ProviderName): boolean {
+  return provider !== 'ollama';
+}
+
+export async function createModel(options: CreateModelOptions): Promise<LanguageModel> {
+  const { provider, apiKey, baseUrl, modelName } = options;
+
   switch (provider) {
     case 'google': {
       const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
-      return createGoogleGenerativeAI({ apiKey })(modelName ?? 'gemini-2.5-flash');
+      return createGoogleGenerativeAI({ apiKey: apiKey! })(modelName ?? 'gemini-2.5-flash');
     }
     case 'openai': {
       const { createOpenAI } = await import('@ai-sdk/openai');
-      return createOpenAI({ apiKey })(modelName ?? 'gpt-5-2');
+      return createOpenAI({ apiKey: apiKey! })(modelName ?? 'gpt-5-2');
     }
     case 'anthropic': {
       const { createAnthropic } = await import('@ai-sdk/anthropic');
-      return createAnthropic({ apiKey })(modelName ?? 'claude-haiku-4-5');
+      return createAnthropic({ apiKey: apiKey! })(modelName ?? 'claude-haiku-4-5');
+    }
+    case 'ollama': {
+      const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible');
+      const defaults = PROVIDER_DEFAULTS.ollama;
+      const provider = createOpenAICompatible({
+        name: 'ollama',
+        baseURL: baseUrl ?? defaults.baseUrl,
+        apiKey: 'ollama',
+      });
+      return provider.chatModel(modelName ?? defaults.model);
+    }
+    case 'openrouter': {
+      const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible');
+      const defaults = PROVIDER_DEFAULTS.openrouter;
+      const provider = createOpenAICompatible({
+        name: 'openrouter',
+        baseURL: baseUrl ?? defaults.baseUrl,
+        apiKey: apiKey!,
+      });
+      return provider.chatModel(modelName ?? defaults.model);
+    }
+    case 'custom': {
+      const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible');
+      if (!baseUrl) throw new Error('Base URL required for custom provider');
+      if (!modelName) throw new Error('Model name required for custom provider');
+      const provider = createOpenAICompatible({
+        name: 'custom',
+        baseURL: baseUrl,
+        apiKey: apiKey ?? 'none',
+      });
+      return provider.chatModel(modelName);
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds support for Ollama, OpenRouter, and custom OpenAI-compatible providers, with automatic fallback for models that don't support structured output.

## Changes

### Provider Support
- Add Ollama provider support (default: \`glm-4.7-flash\`)
- Add OpenRouter provider support (default: \`google/gemini-2.5-flash\`)
- Add generic OpenAI-compatible provider for custom endpoints
- Unified provider configuration with shared settings schema

### Structured Output Fallback
- Automatic fallback to manual JSON parsing when models don't support structured output
- Detects structured output errors (\`response_format.type: json_object\` not supported)
- Handles markdown code blocks in JSON responses
- Maintains schema validation via Zod in fallback path

### Settings Improvements
- Refactor settings to use static namespaced schema
- Fix UI sync issues with dynamic settings
- Unified AI configuration across providers

## Testing
- All existing tests pass
- Added tests for fallback mechanism
- Added tests for new provider types
- Tests verify error handling and markdown code block parsing

## Files Changed
- \`src/vocabulary/providers.ts\` - New provider implementations
- \`src/vocabulary/generator.ts\` - Fallback mechanism
- \`src/logseq/settings.ts\` - Settings schema refactor
- \`src/index.ts\` - Plugin integration updates
- Test files updated with comprehensive coverage